### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 Insights
 ========
 
-[![Latest Version](https://pypip.in/v/insights/badge.png)](https://pypi.python.org/pypi/insights/)
+[![Latest Version](https://img.shields.io/pypi/v/insights.svg)](https://pypi.python.org/pypi/insights/)
 [![Build Status](https://drone.io/github.com/intuition-io/insights/status.png)](https://drone.io/github.com/intuition-io/insights/latest)
 [![Coverage Status](https://coveralls.io/repos/hackliff/insights/badge.png?branch=master)](https://coveralls.io/r/hackliff/insights?branch=master)
 [![Code Health](https://landscape.io/github/intuition-io/insights/master/landscape.png)](https://landscape.io/github/intuition-io/insights/master)
-[![License](https://pypip.in/license/insights/badge.png)](https://pypi.python.org/pypi/insights/)
+[![License](https://img.shields.io/pypi/l/insights.svg)](https://pypi.python.org/pypi/insights/)
 [![Gitter chat](https://badges.gitter.im/intuition-io.png)](https://gitter.im/intuition-io)
 
 > Plug-and-play building blocks for modern quants


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20insights))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `insights`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.